### PR TITLE
Optimise SSE2 bailout.

### DIFF
--- a/mandel_sse2.c
+++ b/mandel_sse2.c
@@ -10,7 +10,6 @@ mandel_sse2(unsigned char *image, const struct spec *s)
     __m128 yscale = _mm_set_ps1((s->ylim[1] - s->ylim[0]) / s->height);
     __m128 threshold = _mm_set_ps1(4);
     __m128 one = _mm_set_ps1(1);
-    __m128i zero = _mm_setzero_si128();
     __m128 iter_scale = _mm_set_ps1(1.0f / s->iterations);
     __m128 depth_scale = _mm_set_ps1(s->depth - 1);
 
@@ -43,8 +42,7 @@ mandel_sse2(unsigned char *image, const struct spec *s)
                 mk = _mm_add_ps(_mm_and_ps(mask, one), mk);
 
                 /* Early bailout? */
-                __m128i maski = _mm_castps_si128(mask);
-                if (0xFFFF == _mm_movemask_epi8(_mm_cmpeq_epi8(maski, zero)))
+                if (_mm_movemask_ps(mask) == 0)
                     break;
             }
             mk = _mm_mul_ps(mk, iter_scale);


### PR DESCRIPTION
This avoids data transfer penalties by using the float movmsk, instead
of the integer one, since the comparison was done on floats. It also
avoids an unnecessary extra comparison, and frees up a register (no need
to store zero anywhere any more).

The end of inner loop changes from

```
pcmpeqb %xmm7, %xmm1
andps   %xmm6, %xmm15
pmovmskb    %xmm1, %eax
cmpl    $65535, %eax
```

to

```
movmskps    %xmm1, %eax
andps   %xmm6, %xmm14
testl   %eax, %eax
```

which is the only major change.

The code is about 1% faster: generating an 4000x2000 image and piping it
to /dev/null goes from 0.400s to 0.396s on my CPU, as measured with `perf stat -r
3` on Linux (with openmp disabled).
