### PR TITLE
Add PowerPC AltiVec port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 mandel.x86
 mandel.arm
+mandel.ppc
 *.o
 *.ppm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 CFLAGS = -std=c99 -Wall -Wextra -Ofast -fopenmp
-CC = /usr/pkg/gcc47/bin/gcc
 
 mandel.ppc : mandel.c mandel_altivec.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
@@ -23,6 +22,6 @@ mandel_neon.o : mandel_neon.c
 	$(CC) -c $(CFLAGS) -mfpu=neon -o $@ $^
 
 clean :
-	$(RM) mandel.x86 mandel.arm mandel.ppc mandel_avx.o mandel_sse2.o mandel_neon.o mandel_altivec.o
+	$(RM) mandel.x86 mandel.arm mandel.ppc mandel_altivec.o mandel_avx.o mandel_sse2.o mandel_neon.o
 
 .PHONY : clean

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
 CFLAGS = -std=c99 -Wall -Wextra -Ofast -fopenmp
+CC = /usr/pkg/gcc47/bin/gcc
+
+mandel.ppc : mandel.c mandel_altivec.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 mandel.x86 : mandel.c mandel_avx.o mandel_sse2.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 mandel.arm : mandel.c mandel_neon.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+mandel_altivec.o : mandel_altivec.c
+	$(CC) -c $(CFLAGS) -maltivec -mabi=altivec -o $@ $^
 
 mandel_avx.o : mandel_avx.c
 	$(CC) -c $(CFLAGS) -mavx -o $@ $^
@@ -16,6 +23,6 @@ mandel_neon.o : mandel_neon.c
 	$(CC) -c $(CFLAGS) -mfpu=neon -o $@ $^
 
 clean :
-	$(RM) mandel.x86 mandel.arm mandel_avx.o mandel_sse2.o mandel_neon.o
+	$(RM) mandel.x86 mandel.arm mandel.ppc mandel_avx.o mandel_sse2.o mandel_neon.o mandel_altivec.o
 
 .PHONY : clean

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ mandel.arm : mandel.c mandel_neon.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 mandel_altivec.o : mandel_altivec.c
-	$(CC) -c $(CFLAGS) -maltivec -mabi=altivec -o $@ $^
+	$(CC) -c $(CFLAGS) -maltivec -o $@ $^
 
 mandel_avx.o : mandel_avx.c
 	$(CC) -c $(CFLAGS) -mavx -o $@ $^

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 CFLAGS = -std=c99 -Wall -Wextra -Ofast -fopenmp
 
-mandel.ppc : mandel.c mandel_altivec.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
-
 mandel.x86 : mandel.c mandel_avx.o mandel_sse2.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 mandel.arm : mandel.c mandel_neon.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+mandel.ppc : mandel.c mandel_altivec.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 mandel_altivec.o : mandel_altivec.c

--- a/mandel.c
+++ b/mandel.c
@@ -5,6 +5,7 @@
 #include "mandel.h"
 
 void mandel_basic(unsigned char *image, const struct spec *s);
+void mandel_altivec(unsigned char *image, const struct spec *s);
 void mandel_avx(unsigned char *image, const struct spec *s);
 void mandel_sse2(unsigned char *image, const struct spec *s);
 void mandel_neon(unsigned char *image, const struct spec *s);
@@ -81,6 +82,11 @@ main(int argc, char *argv[])
     const char *optstring = "w:h:d:k:x:y:N";
     #endif // __arm__
 
+    #ifdef __ppc__
+    int use_altivec = 1;
+    const char *optstring = "w:h:d:k:x:y:A";
+    #endif // __ppc__
+
     /* Parse Options */
     int option;
     while ((option = getopt(argc, argv, optstring)) != -1) {
@@ -119,6 +125,12 @@ main(int argc, char *argv[])
                 break;
             #endif // __arm__
 
+            #ifdef __ppc__
+            case 'A':
+                use_altivec = 0;
+                break;
+            #endif // __ppc__
+
             default:
                 exit(EXIT_FAILURE);
                 break;
@@ -139,6 +151,11 @@ main(int argc, char *argv[])
     if (use_neon)
         mandel_neon(image, &spec);
     #endif // __arm__
+
+    #ifdef __ppc__
+    if (use_altivec)
+        mandel_altivec(image, &spec);
+    #endif // __ppc__
 
     else
         mandel_basic(image, &spec);

--- a/mandel_altivec.c
+++ b/mandel_altivec.c
@@ -50,7 +50,7 @@ mandel_altivec(unsigned char *image, const struct spec *s)
                 /* Increment k */
                 vector float zr2 = vec_madd(zr, zr, zero);
                 vector float mag2 = vec_madd(zi, zi, zr2);
-		vector bool int mask = vec_cmplt(mag2, threshold);
+                vector bool int mask = vec_cmplt(mag2, threshold);
                 mk = vec_add(mk, vec_and(one, mask));
 
                 if(vec_all_ge(mag2, threshold))

--- a/mandel_altivec.c
+++ b/mandel_altivec.c
@@ -42,19 +42,18 @@ mandel_altivec(unsigned char *image, const struct spec *s)
             vector float mk = (vector float) { 1, 1, 1, 1 };
             while (++k < s->iterations) {
                 /* Compute z1 from z0 */
-                vector float zr2 = vec_madd(zr, zr, zero);
+                vector float zr2cr = vec_madd(zr, zr, cr);
                 vector float zi2 = vec_madd(zi, zi, zero);
                 vector float zrzi = vec_madd(zr, zi, zero);
 
                 /* zr1 = zr0 * zr0 - zi0 * zi0 + cr */
                 /* zi1 = zr0 * zi0 + zr0 * zi0 + ci */
-                zr = vec_add(vec_sub(zr2, zi2), cr);
+                zr = vec_sub(zr2cr, zi2);
                 zi = vec_add(vec_add(zrzi, zrzi), ci);
 
                 /* Increment k */
-                zr2 = vec_madd(zr, zr, zero);
-                zi2 = vec_madd(zi, zi, zero);
-                vector float mag2 = vec_add(zr2, zi2);
+                vector float zr2 = vec_madd(zr, zr, zero);
+                vector float mag2 = vec_madd(zi, zi, zr2);
 		vector bool int mask = vec_cmplt(mag2, threshold);
                 mk = vec_add(mk, vec_and(one, mask));
 

--- a/mandel_altivec.c
+++ b/mandel_altivec.c
@@ -1,0 +1,81 @@
+#include <altivec.h>
+#include "mandel.h"
+
+void
+mandel_altivec(unsigned char *image, const struct spec *s)
+{
+    vector float xmin, ymin, xscale, yscale, iter_scale, depth_scale;
+    vector float threshold = (vector float) { 4.0, 4.0, 4.0, 4.0 };
+    vector float one = (vector float) { 1.0, 1.0, 1.0, 1.0 };
+    vector float zero = (vector float) { 0.0, 0.0, 0.0, 0.0 };
+    
+    xmin = (vector float) { s->xlim[0], s->xlim[0], s->xlim[0], s->xlim[0] };
+    ymin = (vector float) { s->ylim[0], s->ylim[0], s->ylim[0], s->ylim[0] };
+    xscale = (vector float) { (s->xlim[1] - s->xlim[0]) / s->width,
+        (s->xlim[1] - s->xlim[0]) / s->width,
+        (s->xlim[1] - s->xlim[0]) / s->width,
+        (s->xlim[1] - s->xlim[0]) / s->width };
+    yscale = (vector float) { (s->ylim[1] - s->ylim[0]) / s->height,
+        (s->ylim[1] - s->ylim[0]) / s->height,
+        (s->ylim[1] - s->ylim[0]) / s->height,
+        (s->ylim[1] - s->ylim[0]) / s->height };
+    iter_scale = (vector float) { 1.0f / s->iterations,
+        1.0f / s->iterations,
+        1.0f / s->iterations,
+        1.0f / s->iterations };
+    depth_scale = (vector float) { s->depth - 1, s->depth - 1,
+        s->depth - 1, s->depth - 1 };
+
+    #pragma omp parallel for schedule(dynamic, 1)
+    for (int y = 0; y < s->height; y++) {
+        for (int x = 0; x < s->width; x += 4) {
+            vector float mx = (vector float)
+                { x, x + 1, x + 2, x + 3 };
+            vector float my = (vector float) 
+                { y, y, y, y };
+            vector float cr = vec_madd(mx, xscale, xmin);
+            vector float ci = vec_madd(my, yscale, ymin);
+            vector float zr = cr;
+            vector float zi = ci;
+
+            int k = 1;
+            vector float mk = (vector float) { 1, 1, 1, 1 };
+            while (++k < s->iterations) {
+                /* Compute z1 from z0 */
+                vector float zr2 = vec_madd(zr, zr, zero);
+                vector float zi2 = vec_madd(zi, zi, zero);
+                vector float zrzi = vec_madd(zr, zi, zero);
+
+                /* zr1 = zr0 * zr0 - zi0 * zi0 + cr */
+                /* zi1 = zr0 * zi0 + zr0 * zi0 + ci */
+                zr = vec_add(vec_sub(zr2, zi2), cr);
+                zi = vec_add(vec_add(zrzi, zrzi), ci);
+
+                /* Increment k */
+                zr2 = vec_madd(zr, zr, zero);
+                zi2 = vec_madd(zi, zi, zero);
+                vector float mag2 = vec_add(zr2, zi2);
+		vector bool int mask = vec_cmplt(mag2, threshold);
+                mk = vec_add(mk, vec_and(one, mask));
+
+                if(vec_all_ge(mag2, threshold))
+                    break;
+            }
+            mk = vec_madd(mk, iter_scale, zero);
+            mk = vec_madd(vec_rsqrte(mk), mk, zero);
+            mk = vec_madd(mk, depth_scale, zero);
+
+
+            vector int pixels = vec_cts(mk, 0);
+
+            unsigned char *dst = image + y * s->width * 3 + x * 3;
+            unsigned char *src = (unsigned char *)&pixels;
+
+            for (int i = 0; i < 4; i++) {
+                dst[i * 3 + 0] = src[(i * 4) + 3];
+                dst[i * 3 + 1] = src[(i * 4) + 3];
+                dst[i * 3 + 2] = src[(i * 4) + 3];
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a functioning PowerPC port and an AltiVec SIMD port. I have tested this only on my Mac Mini G4 (1.5GHz) running Mac OS X Tiger.

Typical results, using gcc 4.0.1 with -O3 and without OpenMP, show a 4.6x improvement:

```
$ time ./mandel.ppc -w 5000 -h 5000 > /dev/null

real    0m4.591s
user    0m4.368s
sys     0m0.202s
$ time ./mandel.ppc -A -w 5000 -h 5000 > /dev/null

real    0m21.134s
user    0m20.793s
sys     0m0.232s
$ 
```

Caveats: Like the NEON port it does not check if the system supports AltiVec. I should also add this is a first foray into AltiVec and SIMD, so this may be far from optimal.
